### PR TITLE
Remove `pytorch` as a dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,12 +41,12 @@ test:
     - transformers.benchmark
     - transformers.commands
     - transformers.data
-    - transformers.data.datasets
-    - transformers.data.metrics
-    - transformers.data.processors
+    - transforemrs.generation
+    - transformers.kernels
     - transformers.models
     - transformers.pipelines
     - transformers.sagemaker
+    - transformers.tools
     - transformers.utils
 
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,6 @@ test:
     - transformers.kernels
     - transformers.models
     - transformers.pipelines
-    - transformers.sagemaker
     - transformers.tools
     - transformers.utils
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -32,7 +32,6 @@ requirements:
     - safetensors
     - packaging >=20.0
     - pyyaml
-    - pytorch >=1.9,!=1.12.0
     - tqdm >=4.27
     - tokenizers >=0.11.1,!=0.11.3,<0.14
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ test:
     - transformers.benchmark
     - transformers.commands
     - transformers.data
-    - transforemrs.generation
     - transformers.kernels
     - transformers.models
     - transformers.pipelines


### PR DESCRIPTION
Discovered while looking through upstream (as a part of #125) that PyTorch is not a core dependency for `transformers` anymore, so removing it.